### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Frontend Build
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/chrizzo84/OllamaUI/security/code-scanning/1](https://github.com/chrizzo84/OllamaUI/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` block in the workflow to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since the workflow only checks out code and builds it, it likely only needs read access to repository contents. The best way to do this is to add a `permissions: contents: read` block at the top level of the workflow (after the `name` field and before `on:`), which will apply to all jobs in the workflow. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
